### PR TITLE
Fix: Correctly parse and reconstruct git URL for deployment

### DIFF
--- a/divisor/deploy.py
+++ b/divisor/deploy.py
@@ -1,5 +1,6 @@
 import os
 import git
+from urllib.parse import urlparse
 
 class Deployer:
     def __init__(self, site_path: str):
@@ -25,10 +26,13 @@ class Deployer:
 
         # Push to the gh-pages branch
         if github_token:
-            if remote_url.startswith("https://"):
-                remote_url = remote_url.replace("https://", f"https://x-access-token:{github_token}@")
-            elif remote_url.startswith("git@"):
-                remote_url = remote_url.replace("git@", f"https://x-access-token:{github_token}@").replace(":", "/")
+            url = urlparse(remote_url)
+            if url.scheme == 'https':
+                url = url._replace(netloc=f"x-access-token:{github_token}@{url.netloc}")
+                remote_url = url.geturl()
+            elif url.scheme == '' and url.path.startswith('git@'):
+                remote_url = f"https://x-access-token:{github_token}@{url.path[4:].replace(':', '/')}"
+
         try:
             repo.git.remote("add", "origin", remote_url)
         except git.exc.GitCommandError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ site_metadata:
   description: "A test site."
   theme: "minima"
   github_pages_url: "https://example.com"
+  github_repository_url: "https://github.com/user/repo.git"
 
 source_repository: "https://example.com/repo.git"
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -14,6 +14,7 @@ site_metadata:
   description: "A test site."
   theme: "minima"
   github_pages_url: "https://example.com"
+  github_repository_url: "https://github.com/user/repo.git"
 
 source_repository: "https://example.com/repo.git"
 

--- a/tests/test_nested_subpages.py
+++ b/tests/test_nested_subpages.py
@@ -14,6 +14,7 @@ site_metadata:
   description: "A test site."
   theme: "minima"
   github_pages_url: "https://example.com"
+  github_repository_url: "https://github.com/user/repo.git"
 
 source_repository: "https://example.com/repo.git"
 


### PR DESCRIPTION
The previous implementation used simple string replacement to add the authentication token to the git URL, which could lead to malformed URLs if the original URL had a trailing slash or other variations.

This commit refactors the deploy method to use `urllib.parse` to robustly handle URL manipulation, ensuring that the authentication token is inserted correctly regardless of the URL format. Additionally, I updated the test suite to reflect the changes in the configuration.