### PR TITLE
feat: Add custom layout to support header and footer across themes

### DIFF
--- a/divisor/_layouts/default.html
+++ b/divisor/_layouts/default.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+{% include header.html %}
+{{ content }}
+{% include footer.html %}

--- a/divisor/jekyll.py
+++ b/divisor/jekyll.py
@@ -65,7 +65,7 @@ class JekyllSite:
         about_path = os.path.join(self.path, "about.md")
         with open(about_path, "w") as f:
             f.write("---\n")
-            f.write("layout: page\n")
+            f.write("layout: default\n")
             f.write(f"title: {self.config.site_metadata.about_page_title}\n")
             f.write("---\n")
             f.write(f"\n{self.config.site_metadata.about_page_body}\n")
@@ -75,7 +75,7 @@ class JekyllSite:
         Copies the template files (_layouts, _includes, assets) to the generated site.
         """
         template_dir = os.path.dirname(__file__)
-        for dir_name in ["_includes"]:
+        for dir_name in ["_includes", "_layouts"]:
             source_dir = os.path.join(template_dir, dir_name)
             dest_dir = os.path.join(self.path, dir_name)
             if os.path.exists(source_dir):


### PR DESCRIPTION
This commit introduces a custom `default.html` layout to ensure that the header and footer are displayed correctly across all supported themes.

The `divisor/jekyll.py` file has been modified to:
- Copy a new `_layouts` directory to the generated site.
- Use the new `default` layout for the about page.

The `divisor/converter.py` already uses the `default` layout, so no changes were needed there.