### PR TITLE
I've fixed a problem with the include syntax in the custom layout. Th…

### DIFF
--- a/divisor/_layouts/default.html
+++ b/divisor/_layouts/default.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    {% include "head-custom.html" %}
+    {% include head-custom.html %}
   </head>
   <body>
     <a id="skip-to-content" href="#content">Skip to the content.</a>


### PR DESCRIPTION
…e Jekyll build was failing because of invalid syntax in the `include` tag. I've removed the quotes around the filename to resolve the issue.