### PR TITLE
feat: Add theme-specific includes for header and footer

### DIFF
--- a/divisor/_includes/cayman-footer.html
+++ b/divisor/_includes/cayman-footer.html
@@ -1,0 +1,4 @@
+<footer class="site-footer">
+  <span class="site-footer-owner"><a href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</a> <a href="https://fonte.wiki">fonte.wiki</a>.</span>
+  <span class="site-footer-credits">Site built with <a href="https://fonte.wiki/projetos/divisor">Divisor</a>.</span>
+</footer>

--- a/divisor/_includes/cayman-header.html
+++ b/divisor/_includes/cayman-header.html
@@ -1,0 +1,5 @@
+<header class="page-header" role="banner">
+  <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+  <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+  <a href="/about" class="btn">Saiba Mais</a>
+</header>

--- a/divisor/_layouts/default.html
+++ b/divisor/_layouts/default.html
@@ -1,0 +1,36 @@
+---
+---
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+
+{% seo %}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style" type="text/css" crossorigin>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#157878">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% include head-custom.html %}
+  </head>
+  <body>
+    <a id="skip-to-content" href="#content">Skip to the content.</a>
+
+    {% if site.theme == "minima" %}
+      {% include header.html %}
+    {% elsif site.theme == "jekyll-theme-cayman" %}
+      {% include cayman-header.html %}
+    {% endif %}
+
+    <main id="content" class="main-content" role="main">
+      {{ content }}
+    </main>
+
+    {% if site.theme == "minima" %}
+      {% include footer.html %}
+    {% elsif site.theme == "jekyll-theme-cayman" %}
+      {% include cayman-footer.html %}
+    {% endif %}
+  </body>
+</html>

--- a/divisor/jekyll.py
+++ b/divisor/jekyll.py
@@ -75,7 +75,7 @@ class JekyllSite:
         Copies the template files (_layouts, _includes, assets) to the generated site.
         """
         template_dir = os.path.dirname(__file__)
-        for dir_name in ["_includes"]:
+        for dir_name in ["_includes", "_layouts"]:
             source_dir = os.path.join(template_dir, dir_name)
             dest_dir = os.path.join(self.path, dir_name)
             if os.path.exists(source_dir):


### PR DESCRIPTION
This commit introduces a more robust way of handling custom headers and footers across different themes.

- A custom `default.html` layout has been re-introduced.
- Theme-specific include files have been created for the Cayman theme.
- The custom layout now uses Liquid tags to conditionally include the correct header and footer based on the theme name.