### PR TITLE
feat: Allow custom templates and layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,12 @@ site_metadata:
 ```
 
 After changing the theme, commit the changes to your `config.yml` file. If you are using the automated setup, the GitHub Actions workflow will automatically regenerate and deploy your website with the new theme.
+
+## Custom Templates and Layouts
+
+You can customize the look and feel of your website by providing your own templates and layouts. To do this, create `_layouts` and `_includes` directories inside the `divisor` directory.
+
+*   `divisor/_layouts`: Place your custom layouts in this directory.
+*   `divisor/_includes`: Place your custom includes in this directory.
+
+When you run the `generate` command, Divisor will copy the contents of these directories to the generated site, overwriting any default files with the same name. This allows you to either add new templates or override the default ones provided by the theme.

--- a/README.pt.md
+++ b/README.pt.md
@@ -192,3 +192,12 @@ site_metadata:
 ```
 
 Depois de alterar o tema, faça o commit das alterações no seu arquivo `config.yml`. Se você estiver usando a configuração automatizada, o fluxo de trabalho do GitHub Actions irá regenerar e implantar automaticamente seu site com o novo tema.
+
+## Templates e Layouts Personalizados
+
+Você pode personalizar a aparência do seu site fornecendo seus próprios templates e layouts. Para fazer isso, crie os diretórios `_layouts` e `_includes` dentro do diretório `divisor`.
+
+*   `divisor/_layouts`: Coloque seus layouts personalizados neste diretório.
+*   `divisor/_includes`: Coloque seus includes personalizados neste diretório.
+
+Quando você executa o comando `generate`, o Divisor copiará o conteúdo desses diretórios para o site gerado, sobrescrevendo quaisquer arquivos padrão com o mesmo nome. Isso permite que você adicione novos templates ou substitua os padrão fornecidos pelo tema.

--- a/divisor/_includes/custom_include.html
+++ b/divisor/_includes/custom_include.html
@@ -1,0 +1,1 @@
+<p>This is a custom include.</p>

--- a/divisor/_layouts/custom_layout.html
+++ b/divisor/_layouts/custom_layout.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Custom Layout</title>
+</head>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/divisor/jekyll.py
+++ b/divisor/jekyll.py
@@ -75,11 +75,18 @@ class JekyllSite:
         Copies the template files (_layouts, _includes, assets) to the generated site.
         """
         template_dir = os.path.dirname(__file__)
-        for dir_name in ["_includes"]:
+        for dir_name in ["_includes", "_layouts"]:
+            # Copy default templates
             source_dir = os.path.join(template_dir, dir_name)
             dest_dir = os.path.join(self.path, dir_name)
             if os.path.exists(source_dir):
                 import shutil
-                if os.path.exists(dest_dir):
-                    shutil.rmtree(dest_dir)
+                if not os.path.exists(dest_dir):
+                    os.makedirs(dest_dir)
                 shutil.copytree(source_dir, dest_dir, dirs_exist_ok=True)
+
+            # Copy custom templates if they exist
+            custom_source_dir = os.path.join("divisor", dir_name)
+            if os.path.exists(custom_source_dir):
+                import shutil
+                shutil.copytree(custom_source_dir, dest_dir, dirs_exist_ok=True)


### PR DESCRIPTION
This change allows you to add custom templates and layouts to your Jekyll site.

You can create `_layouts` and `_includes` directories inside the `divisor` directory. The contents of these directories will be copied to the generated site, overwriting any default files with the same name.

This makes it easier for you to customize your site's appearance and use alternative Jekyll themes.