### PR TITLE
feat: Add extended.css for your customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,7 @@ To add your own custom templates, create `_layouts` and `_includes` directories 
 *   `divisor/_includes`: Place your custom includes in this directory.
 
 When you run the `generate` command, Divisor will copy the contents of these directories to the generated site, overwriting any default files with the same name. This allows you to either add new templates or override the default ones provided by the theme.
+
+### Customizing the CSS
+
+To add your own custom CSS, you can create a file named `extended.css` in the `divisor/assets` directory. This file will be loaded after the theme's default CSS, allowing you to override any styles you want.

--- a/README.pt.md
+++ b/README.pt.md
@@ -202,6 +202,10 @@ Você pode personalizar a aparência do seu site fornecendo seus próprios templ
 
 Quando você executa o comando `generate`, o Divisor copiará o conteúdo desses diretórios para o site gerado, sobrescrevendo quaisquer arquivos padrão com o mesmo nome. Isso permite que você adicione novos templates ou substitua os padrão fornecidos pelo tema.
 
+### Personalizando o CSS
+
+Para adicionar seu próprio CSS personalizado, você pode criar um arquivo chamado `extended.css` no diretório `divisor/assets`. Este arquivo será carregado após o CSS padrão do tema, permitindo que você substitua quaisquer estilos que desejar.
+
 ## Limpando o ambiente
 
 Para remover os diretórios `source_repo` e `site_contents`, você pode usar o comando `clean`:

--- a/divisor/_includes/head-custom.html
+++ b/divisor/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ "/assets/extended.css" | relative_url }}">

--- a/divisor/assets/extended.css
+++ b/divisor/assets/extended.css
@@ -1,0 +1,4 @@
+/*
+This file is intentionally left blank.
+You can add your own custom CSS here to override the default theme.
+*/


### PR DESCRIPTION
This change adds an `extended.css` file to the `divisor/assets` directory. This file is loaded after the theme's default CSS, allowing you to easily customize the site's appearance by adding your own CSS.

The `head-custom.html` include has been updated to link to the `extended.css` file, and the documentation has been updated to explain how to use it.