### PR TITLE
Make Divisor more theme-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ When you run the `generate` command, Divisor will copy the contents of these dir
 
 ### Customizing the CSS
 
-To add your own custom CSS, you can create a file named `extended.css` in the `divisor/assets` directory. This file will be loaded after the theme's default CSS, allowing you to override any styles you want. For the `minima` theme, you can also customize the theme's variables by creating a `main.scss` file in the `divisor/assets/minima` directory.
+To add your own custom CSS, you can create a file named `extended.css` in the `divisor/assets` directory. This file will be loaded after the theme's default CSS, allowing you to override any styles you want. This is the recommended way to add custom styles for any theme.

--- a/README.pt.md
+++ b/README.pt.md
@@ -206,7 +206,7 @@ Quando você executa o comando `generate`, o Divisor copiará o conteúdo desses
 
 ### Personalizando o CSS
 
-Para adicionar seu próprio CSS personalizado, você pode criar um arquivo chamado `extended.css` no diretório `divisor/assets`. Este arquivo será carregado após o CSS padrão do tema, permitindo que você substitua quaisquer estilos que desejar. Para o tema `minima`, você também pode personalizar as variáveis do tema criando um arquivo `main.scss` no diretório `divisor/assets/minima`.
+Para adicionar seu próprio CSS personalizado, você pode criar um arquivo chamado `extended.css` no diretório `divisor/assets`. Este arquivo será carregado após o CSS padrão do tema, permitindo que você substitua quaisquer estilos que desejar. Esta é a maneira recomendada de adicionar estilos personalizados para qualquer tema.
 
 ## Limpando o ambiente
 

--- a/divisor/assets/minima/main.scss
+++ b/divisor/assets/minima/main.scss
@@ -1,4 +1,0 @@
----
----
-
-@import "minima";


### PR DESCRIPTION
This change makes Divisor more theme-agnostic by removing hardcoded theme-specific files and updating the documentation. The goal is to allow you to easily switch to other themes without our customizations interfering.

Changes:
- Removed the `divisor/assets/minima` directory, which contained customizations specific to the `minima` theme.
- Updated the `README.md` and `README.pt.md` files to reflect these changes and to clarify that `extended.css` is the recommended way to add custom styles for any theme.