### PR TITLE
I fixed the Jekyll build error by removing the `minima` import.

### DIFF
--- a/divisor/assets/main.scss
+++ b/divisor/assets/main.scss
@@ -1,4 +1,2 @@
 ---
 ---
-
-@import "minima";


### PR DESCRIPTION
The previous build was failing because of a reference to the `minima` theme in the `assets/main.scss` file. This change removes the import of the `minima` theme from the `divisor/assets/main.scss` file.