### PR TITLE
I've made some changes to fix an issue where the `minima` theme was n…

### DIFF
--- a/divisor/assets/minima.scss
+++ b/divisor/assets/minima.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import "minima";

--- a/divisor/jekyll.py
+++ b/divisor/jekyll.py
@@ -100,11 +100,10 @@ class JekyllSite:
                 os.makedirs(dest_dir)
             shutil.copy2(os.path.join(source_dir, "extended.css"), dest_dir)
 
+        # Conditionally copy main.scss for minima theme
         if self.config.site_metadata.theme == "minima":
-            source_dir = os.path.join(template_dir, "assets", "minima")
-            dest_dir = os.path.join(self.path, "assets")
-            if os.path.exists(source_dir):
+            source_file = os.path.join(template_dir, "assets", "minima.scss")
+            dest_file = os.path.join(self.path, "assets", "main.scss")
+            if os.path.exists(source_file):
                 import shutil
-                if not os.path.exists(dest_dir):
-                    os.makedirs(dest_dir)
-                shutil.copytree(source_dir, dest_dir, dirs_exist_ok=True)
+                shutil.copy2(source_file, dest_file)


### PR DESCRIPTION
…ot being styled correctly and to improve the theme agnosticism of the tool.

Here's what I did:
- I created a new `divisor/assets/minima.scss` file that contains the `@import "minima";` rule.
- I modified `divisor/jekyll.py` to conditionally copy the `minima.scss` file to the generated site's `assets` directory and rename it to `main.scss` only when the selected theme is `minima`.
- I emptied the `divisor/assets/main.scss` file.