### PR TITLE
fix: allow customizing minima theme assets

### DIFF
--- a/divisor/jekyll.py
+++ b/divisor/jekyll.py
@@ -92,12 +92,6 @@ class JekyllSite:
                         continue
                     shutil.copy2(s, d)
 
-            # Copy custom templates if they exist
-            custom_source_dir = os.path.join("divisor", "assets")
-            if os.path.exists(custom_source_dir):
-                import shutil
-                shutil.copytree(custom_source_dir, dest_dir, dirs_exist_ok=True)
-
         # Copy extended.css
         source_dir = os.path.join(template_dir, "assets")
         dest_dir = os.path.join(self.path, "assets")
@@ -114,3 +108,10 @@ class JekyllSite:
                 f.write("---\n")
                 f.write("---\n")
                 f.write('@import "minima";\n')
+
+        # Copy custom templates if they exist
+        custom_source_dir = os.path.join("divisor", "assets")
+        if os.path.exists(custom_source_dir):
+            import shutil
+            dest_dir = os.path.join(self.path, "assets")
+            shutil.copytree(custom_source_dir, dest_dir, dirs_exist_ok=True)


### PR DESCRIPTION
This fixes an issue where custom assets placed in `divisor/assets/` (such as `extended.css` or `main.scss`) were being blindly overwritten by the generated default theme assets for the `minima` theme during site generation. The logic to copy custom templates has been moved to the very end of the `copy_template_files` function so it correctly overrides the generated files.

---
*PR created automatically by Jules for task [16459920852801562273](https://jules.google.com/task/16459920852801562273) started by @efeefe*